### PR TITLE
loginの挙動を修正

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -50,7 +50,7 @@ func (s *Server) buildRoutes() {
 	s.muxer.Handle(config.Path, s.AuthCallbackHandler())
 
 	// Add login / logout handler
-	s.muxer.Handle(config.Path+"/login", s.LoginHandler("default"))
+	s.muxer.Handle(config.Path+"/login", s.LoginHandler(config.DefaultProvider))
 	s.muxer.Handle(config.Path+"/logout", s.LogoutHandler())
 
 	// Add health check handler


### PR DESCRIPTION
https://github.com/traPtitech/traefik-forward-auth/blob/main/internal/server.go#L318  
ruleを設定しなかった場合、ここでnilが返されてしまい、その後panicを起こしてしまっていたのを修正